### PR TITLE
fix: bad ux behavior on options change and multiple on change

### DIFF
--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -194,7 +194,7 @@ export default {
 
 <style src="@vueform/multiselect/themes/default.css"></style>
 
-<style type="scss">
+<style type="scss" scoped>
 .input-multiselect {
     --ms-font-size: var(--font-size);
     --ms-option-font-size: var(--font-size);
@@ -210,25 +210,28 @@ export default {
     }
     /* wwEditor:end */
 }
-.multiselect-tag {
-    padding: 4px;
-    border-radius: 4px;
-}
-.multiselect.is-active {
-    box-shadow: unset;
-}
 
-.multiselect-caret,
-.multiselect-clear-icon,
-.multiselect-tag-remove-icon {
-    width: var(--font-size);
-    height: var(--font-size);
-}
-.multiselect-caret {
-    margin-top: 10px;
-    margin-bottom: 10px;
-}
-.multiselect-dropdown {
-    max-height: unset;
+.input-multiselect::v-deep {
+    .multiselect-tag {
+        padding: 4px;
+        border-radius: 4px;
+    }
+    .multiselect.is-active {
+        box-shadow: unset;
+    }
+
+    .multiselect-caret,
+    .multiselect-clear-icon,
+    .multiselect-tag-remove-icon {
+        width: var(--font-size);
+        height: var(--font-size);
+    }
+    .multiselect-caret {
+        margin-top: 10px;
+        margin-bottom: 10px;
+    }
+    .multiselect-dropdown {
+        max-height: unset;
+    }
 }
 </style>

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -52,12 +52,13 @@ export default {
         wwEditorState: { type: Object, required: true },
         /* wwEditor:end */
     },
-    setup(props) {
+    setup(props, { emit }) {
         const { value: currentSelection, setValue: setCurrentSelection } = wwLib.wwVariable.useComponentVariable({
             uid: props.uid,
             name: 'currentSelection',
             type: 'array',
             defaultValue: Array.isArray(props.content.initialValue) ? props.content.initialValue : [],
+            onUpdate: value => emit('trigger-event', { name: 'change', event: { domEvent: {}, value } }),
         });
         return { currentSelection, setCurrentSelection };
     },
@@ -104,14 +105,11 @@ export default {
         },
     },
     watch: {
-        'content.initialValue'() {
-            this.init();
+        'content.initialValue'(value) {
+            this.refreshInitialValue();
         },
         'content.options'() {
-            this.init();
-        },
-        currentSelection(value) {
-            this.$emit('trigger-event', { name: 'change', event: { domEvent: {}, value } });
+            this.refreshOptions();
         },
         /* wwEditor:start */
         'wwEditorState.boundProps.options'(isBind) {
@@ -126,11 +124,7 @@ export default {
         /* wwEditor:end */
     },
     methods: {
-        async init() {
-            // reset selection and option to avoid mismatch
-            this.internalValue = [];
-            this.options = [];
-
+        init() {
             const initialOptions = Array.isArray(this.content.options) ? this.content.options : [];
             const initialValue = Array.isArray(this.content.initialValue) ? this.content.initialValue : [];
 
@@ -140,10 +134,35 @@ export default {
                 ...initialValue.filter(selection => !this.options.map(option => option.value).includes(selection))
             );
 
-            // await to avoid mismatch (multiselect not rendering custom tags)
-            await this.$nextTick();
+            // We set internalValue after the options to avoid mismatch
+            this.internalValue = initialValue;
+        },
+        /**
+         * We need to avoid to have a value not present in options
+         * So here we take care of not removing an used option
+         */
+        refreshOptions() {
+            // we removed unused options
+            this.options = this.options.filter(option => this.internalValue.includes(option.value));
 
-            this.internalValue = [...initialValue];
+            // Then we add the new initial options and avoid duplicate
+            const initialOptions = Array.isArray(this.content.options) ? this.content.options : [];
+            const newOptions = initialOptions.filter(
+                option => !this.options.some(currentOpt => currentOpt.value === option.value)
+            );
+            this.options.push(...newOptions.map(option => this.formatOption(option)));
+
+            // Then we add current selection as custom options if not already included
+            this.options.push(
+                ...this.internalValue.filter(selection => !this.options.map(option => option.value).includes(selection))
+            );
+        },
+        refreshInitialValue() {
+            const initialValue = Array.isArray(this.content.initialValue) ? this.content.initialValue : [];
+            this.options.push(
+                ...initialValue.filter(selection => !this.options.map(option => option.value).includes(selection))
+            );
+            this.internalValue = initialValue;
         },
         formatOption(option) {
             const labelField = this.content.labelField || DEFAULT_LABEL_FIELD;

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -105,7 +105,7 @@ export default {
         },
     },
     watch: {
-        'content.initialValue'(value) {
+        'content.initialValue'() {
             this.refreshInitialValue();
         },
         'content.options'() {
@@ -125,8 +125,8 @@ export default {
     },
     methods: {
         init() {
-            const initialOptions = Array.isArray(this.content.options) ? this.content.options : [];
-            const initialValue = Array.isArray(this.content.initialValue) ? this.content.initialValue : [];
+            const initialOptions = Array.isArray(this.content.options) ? [...this.content.options] : [];
+            const initialValue = Array.isArray(this.content.initialValue) ? [...this.content.initialValue] : [];
 
             this.options.push(...initialOptions.map(option => this.formatOption(option)));
             // add initial values as custom options if not already included
@@ -146,7 +146,7 @@ export default {
             this.options = this.options.filter(option => this.internalValue.includes(option.value));
 
             // Then we add the new initial options and avoid duplicate
-            const initialOptions = Array.isArray(this.content.options) ? this.content.options : [];
+            const initialOptions = Array.isArray(this.content.options) ? [...this.content.options] : [];
             const newOptions = initialOptions.filter(
                 option => !this.options.some(currentOpt => currentOpt.value === option.value)
             );
@@ -158,7 +158,7 @@ export default {
             );
         },
         refreshInitialValue() {
-            const initialValue = Array.isArray(this.content.initialValue) ? this.content.initialValue : [];
+            const initialValue = Array.isArray(this.content.initialValue) ? [...this.content.initialValue] : [];
             this.options.push(
                 ...initialValue.filter(selection => !this.options.map(option => option.value).includes(selection))
             );

--- a/ww-config.js
+++ b/ww-config.js
@@ -1,8 +1,8 @@
 export default {
     editor: {
         label: {
-            en: 'Input multiselect',
-            fr: 'Champs sélection multiple',
+            en: 'Input multiselect (legacy)',
+            fr: 'Champs sélection multiple (legacy)',
         },
         icon: 'fontawesome/solid/chevron-circle-down',
         bubble: {


### PR DESCRIPTION
J'ai pas pu simplifier le code malheureusement, cette contrainte de toujours devoir éviter que le composant entre dans un état où ses valeurs ne sont pas comprise dans ses options ça rajoute de la complexité, surtout dans notre cas où les options et les valeurs peuvent être changé par différent mécanismes.

J'ai pu éviter les await nextTick et les onChange multiple à l'init et quand on change les options et le initialValue, il se comporte beaucoup mieux comme ça

Attention a bien merge la PR de l'éditor avant celle ci, j'utilise le hook onUpdate de nos wwVariable qui a reçu un patch