### PR TITLE
WW-1892-multiselect-input-free-layout-remove-icon

### DIFF
--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -134,6 +134,7 @@ export default {
                 name: this.wwElementState.name,
                 infinite: this.content.infiniteScroll,
                 limit: this.content.limitedOptions ? this.content.limit : -1,
+                max: this.content.maxSelection ? this.content.max : -1,
                 resolveOnLoad: false,
                 locale: this.currentLang,
             };

--- a/ww-config.js
+++ b/ww-config.js
@@ -505,6 +505,7 @@ export default {
             },
             navigator: {
                 group: 'Option - Selected',
+                hidden: content => content.layoutType === 'free',
             },
         },
         caretIconElement: {

--- a/ww-config.js
+++ b/ww-config.js
@@ -280,6 +280,32 @@ export default {
             defaultValue: 20,
             section: 'settings',
         },
+        maxSelection: {
+            hidden: content => !content.advanced,
+            label: {
+                en: 'Max selection',
+                fr: 'Max selection',
+            },
+            type: 'OnOff',
+            defaultValue: false,
+            section: 'settings',
+        },
+        max: {
+            hidden: content => !content.advanced || !content.maxSelection,
+            type: 'Number',
+            label: {
+                en: 'Max',
+                fr: 'Max',
+            },
+            options: {
+                min: 0,
+                max: 50,
+                step: 1,
+            },
+            defaultValue: 1,
+            section: 'settings',
+            bindable: true,
+        },
         clearIcon: {
             label: {
                 en: 'Clear icon',


### PR DESCRIPTION
@kevinbarfleur J'ai vu le remove icon commenté dans le code quand on est en free layout, on considère donc que c'est à l'utilisateur de faire sa propre logique de remove c'est ça ?