### PR TITLE
fix(WW-3544): cursor via css() hook instead of inject('componentStyle')

### DIFF
--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -81,7 +81,7 @@
 
 <script>
 import Multiselect from '@vueform/multiselect';
-import { computed, inject } from 'vue';
+import { computed } from 'vue';
 import OptionItem from './OptionItem.vue';
 import OptionItemSelected from './OptionItemSelected.vue';
 
@@ -107,11 +107,7 @@ export default {
             defaultValue: computed(() => (Array.isArray(props.content.initialValue) ? props.content.initialValue : [])),
         });
 
-        const styles = inject('componentStyle');
-
-        const cursor = computed(() => styles.cursor);
-
-        return { currentSelection, setCurrentSelection, cursor };
+        return { currentSelection, setCurrentSelection };
     },
     data: () => ({
         options: [],
@@ -219,7 +215,6 @@ export default {
                 '--search-font-size': this.content.searchFontSize || 'inherit',
                 '--search-font-family': this.content.searchFontFamily || 'inherit',
                 '--search-font-color': this.content.searchFontColor || 'inherit',
-                '--component-cursor': this.cursor || 'pointer',
                 '--padding-tag': this.content.layoutType === 'text' ? '4px' : '0',
             };
         },
@@ -474,7 +469,7 @@ export default {
 
 <style type="scss" scoped>
 .input-multiselect {
-    cursor: var(--component-cursor);
+    cursor: var(--component-cursor, pointer);
     --ms-border-width: 0px;
     position: relative;
     /* min-height: calc(var(--font-size) + 20px); */
@@ -485,7 +480,7 @@ export default {
     }
 }
 .input-multiselect:deep(.multiselect-wrapper) {
-    cursor: var(--component-cursor);
+    cursor: var(--component-cursor, pointer);
     height: inherit;
     min-height: unset;
 }

--- a/ww-config.js
+++ b/ww-config.js
@@ -1,4 +1,14 @@
 export default {
+    css({ style }) {
+        // Expose the element cursor as a CSS variable so the inner multiselect nodes can consume it
+        // through the style compiler, instead of injecting the resolved `componentStyle` in JS.
+        return [
+            {
+                property: '--component-cursor',
+                value: style.cursor,
+            },
+        ];
+    },
     editor: {
         label: {
             en: 'Input multiselect',


### PR DESCRIPTION
## Contexte

Le chantier "CSS pur" (WW-3544) supprime `provide('componentStyle')` côté éditeur/runtime. `ww-input-multiselect` faisait `inject('componentStyle')` puis lisait `styles.cursor` → sans provide, `styles` est `undefined` → crash sur `.cursor` (éditeur + publié).

## Fix

Même pattern que le fix ww-image : le composant expose le `cursor` de l'élément en variable CSS via le hook `css()` de `ww-config`, résolu et émis par le compilateur sur la règle de l'élément, consommé par les nœuds internes en `var(--component-cursor, pointer)`.

- `ww-config.js` : ajout du hook `css({ style }) → [{ property: '--component-cursor', value: style.cursor }]`.
- `src/wwElement.vue` : retrait de `inject('componentStyle')` + du computed `cursor` + du binding inline `--component-cursor` ; fallback `pointer` déplacé dans le CSS.

Le cursor reste responsive/statefull (le hook `css()` tourne par slot) et n'utilise plus l'objet style résolu en JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)